### PR TITLE
Add ability to customize title-bar title.

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -44,7 +44,12 @@ export interface TitlebarConstructorOptions {
    * Set the order of the elements on the title bar.
    * *The default value is normal*
    */
-  order?: ('normal' | 'reverse' | 'firstButtons');
+  order?: "normal" | "reverse" | "firstButtons";
+  /**
+   * Set horizontal alignment of the window title.
+   * *The default value is center*
+   */
+  titleHorizontalAlignment?: "left" | "center" | "right";
   /**
    * The background color when the mouse is over the item
    */

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -37,6 +37,7 @@
 		text-overflow: ellipsis;
 		margin-left: auto;
 		margin-right: auto;
+		padding-top: 3px;
 		zoom: 1;
   }
   

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -35,9 +35,8 @@
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
-		margin-left: auto;
-		margin-right: auto;
 		padding-top: 3px;
+		width: 100%;
 		zoom: 1;
   }
   

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -7,6 +7,7 @@ import { TitlebarConstructorOptions } from './options';
 import { GlobalTitlebar } from './global';
 
 const Color = require('color');
+const allowAlign = ['left', 'center', 'right'];
 
 export class Titlebar extends GlobalTitlebar {
   private currentWindow: BrowserWindow;
@@ -20,7 +21,8 @@ export class Titlebar extends GlobalTitlebar {
     maximizable: true,
     closeable: true,
     order: 'normal',
-    menuItemHoverColor: 'rgba(0, 0, 0, .14)'
+    menuItemHoverColor: 'rgba(0, 0, 0, .14)',
+    titleHorizontalAlignment: 'center'
   };
 
   /**
@@ -58,6 +60,26 @@ export class Titlebar extends GlobalTitlebar {
     }
 
     titlebarChildren.push(this.$('.window-appicon'));
+
+    if (allowAlign.some(x => x === this.options.titleHorizontalAlignment)) {
+      if (this.options.icon === null) {
+        if (this.options.titleHorizontalAlignment == 'left' && this.options.order !== "reverse") {
+          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: left; padding-left: 15px` }))
+        } else if (this.options.titleHorizontalAlignment == 'right' && this.options.order == "reverse" || this.options.order == "firstButtons") {
+          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: right; padding-right: 15px` }))
+        } else {
+          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: ${this.options.titleHorizontalAlignment};` }))
+        }
+      } else {
+        if (this.options.titleHorizontalAlignment == 'right' && this.options.order == "firstButtons") {
+          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: right; padding-right: 15px` }))
+        } else {
+          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: ${this.options.titleHorizontalAlignment};` }))
+        }
+      }
+    } else {
+      titlebarChildren.push(this.$('.window-title', { 'style': 'text-align: center;' }))
+    }
 
     if (this.options.menu) {
       titlebarChildren.push(this.$('.menubar', { 'role': 'menubar' }));
@@ -236,6 +258,38 @@ export class Titlebar extends GlobalTitlebar {
       const newTheme = this.$('style#icons-style');
       newTheme.textContent = theme.textContent;
       document.head.appendChild(newTheme);
+    }
+  }
+
+  /**
+  * set horizontal alignment of the window title
+  */
+  setHorizontalAlignment(side: String) {
+    let wTitle = document.querySelector(".window-title") as HTMLElement;
+
+    if (wTitle) {
+      if (allowAlign.some(x => x === side)) {
+        if (this.options.icon === null) {
+          if (side == "left" && this.options.order !== "reverse") {
+            wTitle.style.textAlign = "left";
+            wTitle.style.paddingLeft = "15px";
+          } else if ((side == "right" && this.options.order == "reverse") || this.options.order == "firstButtons") {
+            wTitle.style.textAlign = "right";
+            wTitle.style.paddingRight = "15px";
+          } else {
+            wTitle.style.textAlign = String(side);
+          }
+        } else {
+          if (this.options.titleHorizontalAlignment == "right" && this.options.order == "firstButtons") {
+            wTitle.style.textAlign = "right";
+            wTitle.style.paddingRight = "15px";
+          } else {
+            wTitle.style.textAlign = String(side);
+          }
+        }
+      } else {
+        wTitle.style.textAlign = "center";
+      }
     }
   }
 

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -85,8 +85,6 @@ export class Titlebar extends GlobalTitlebar {
       titlebarChildren.push(this.$('.menubar', { 'role': 'menubar' }));
     }
 
-    titlebarChildren.push(this.$('.window-title'));
-
     if (platform !== 'darwin') {
       titlebarChildren.push(this.$('.window-controls-container', {},
         ...[
@@ -265,7 +263,7 @@ export class Titlebar extends GlobalTitlebar {
   * set horizontal alignment of the window title
   */
   setHorizontalAlignment(side: String) {
-    let wTitle = document.querySelector(".window-title") as HTMLElement;
+    const wTitle = document.querySelector(".window-title") as HTMLElement;
 
     if (wTitle) {
       if (allowAlign.some(x => x === side)) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39625750/51410394-94052700-1b75-11e9-9ef8-1b46dd736228.png)

![image](https://user-images.githubusercontent.com/39625750/51410404-9a939e80-1b75-11e9-9d92-53c74e4124dd.png)

![image](https://user-images.githubusercontent.com/39625750/51410410-a0897f80-1b75-11e9-8982-e621bae63e44.png)

![image](https://user-images.githubusercontent.com/39625750/51410459-c6af1f80-1b75-11e9-84c2-68323b310844.png)

![image](https://user-images.githubusercontent.com/39625750/51410498-dd557680-1b75-11e9-9e4c-8c945a68cafa.png)

Horizontal alignment can be applied as option: `titleHorizontalAlignment: 'left'`
And can be called as method: `titleBar.setHorizontalAlignment('left')`

Values what can get `setHorizontalAlignment` method:
> `left` - align title on left side in title-bar.
> `right` - align title on right side in title-bar.
> `center` - align title on center in title-bar.

###### Usage example:

```
      const customTitlebar = require('custom-electron-titlebar')

      let titleBar = new customTitlebar.Titlebar('#303030', {
        icon: './favicon.svg',
        iconsStyle: customTitlebar.Themebar.win,
        titleHorizontalAlignment: 'left',
        menu: null,
        order: 'normal'
      })

      titleBar.setHorizontalAlignment('left') // also can be used as method.
```

**Know bugs**: bad compatibility with menu. I think menu need in re-code, menu coded so bad.