### PR TITLE
Many library improvements, more customization.

### DIFF
--- a/src/global.ts
+++ b/src/global.ts
@@ -1,66 +1,84 @@
-const Color = require('color');
+const Color = require("color");
 
 export class GlobalTitlebar {
-	$<T extends HTMLElement>(description: string, attrs?: { [key: string]: any; }, ...children: (Node | string)[]): T {
-		let match = /([\w\-]+)?(#([\w\-]+))?((.([\w\-]+))*)/.exec(description);
+  $<T extends HTMLElement>(
+    description: string,
+    attrs?: { [key: string]: any },
+    ...children: (Node | string)[]
+  ): T {
+    let match = /([\w\-]+)?(#([\w\-]+))?((.([\w\-]+))*)/.exec(description);
 
-		if (!match) {
-			throw new Error('Bad use of emmet');
-		}
+    if (!match) {
+      throw new Error("Bad use of emmet");
+    }
 
-		let result = document.createElement(match[1] || 'div');
+    let result = document.createElement(match[1] || "div");
 
-		if (match[3]) {
-			result.id = match[3];
-		}
-		if (match[4]) {
-			result.className = match[4].replace(/\./g, ' ').trim();
-		}
+    if (match[3]) {
+      result.id = match[3];
+    }
+    if (match[4]) {
+      result.className = match[4].replace(/\./g, " ").trim();
+    }
 
-		attrs = attrs || {};
-		Object.keys(attrs).forEach(name => {
-			const value = attrs![name];
-			if (/^on\w+$/.test(name)) {
-				(<any>result)[name] = value;
-			} else {
-				result.setAttribute(name, value);
-			}
-		});
+    attrs = attrs || {};
+    Object.keys(attrs).forEach(name => {
+      const value = attrs![name];
+      if (/^on\w+$/.test(name)) {
+        (<any>result)[name] = value;
+      } else {
+        result.setAttribute(name, value);
+      }
+    });
 
-		children.forEach(child => {
-			if (child instanceof Node) {
-				result.appendChild(child);
-			} else {
-				result.appendChild(document.createTextNode(child as string));
-			}
-		});
+    children.forEach(child => {
+      if (child instanceof Node) {
+        result.appendChild(child);
+      } else {
+        result.appendChild(document.createTextNode(child as string));
+      }
+    });
 
-		return result as T;
-	}
+    return result as T;
+  }
 
-	setColors(color: string): void {
-		let styleElement = document.getElementById('titlebar-style-icons');
-		let style: HTMLStyleElement | HTMLElement;
-	
-		if(!styleElement) {
-			style = this.$('style#titlebar-style-icons');
-		} else {
-			style = styleElement;
-		}
-	
-		style.textContent = `.titlebar > .window-controls-container .window-icon {
-			background-color: ${Color(color).isDark() && color !== 'transparent' ? '#ffffff' : '#333333'};
-		}
-		
-		.menu-container .menu-item-check, .menu-container .submenu-indicator {
-			background-color: ${Color(color).isDark() && color !== 'transparent' ? '#ffffff' : '#333333'};
-		}`;
-	
-		if(!styleElement) document.head.appendChild(style);
-	
-		document.querySelectorAll<HTMLElement>('.menubar-menu-items-holder').forEach(menu => {
-			menu.style.backgroundColor = color !== 'transparent' ? Color(color).darken(0.12) : '#EDEDED';
-			menu.style.color = Color(color).isDark() && color !== 'transparent' ? '#ffffff' : '#333333';;
-		});
-	}
+  setColors(color: string): void {
+    let styleElement = document.getElementById("titlebar-style-icons");
+    let style: HTMLStyleElement | HTMLElement;
+
+    if (!styleElement) {
+      style = this.$("style#titlebar-style-icons");
+    } else {
+      style = styleElement;
+    }
+
+    style.textContent = `.titlebar > .window-controls-container .window-icon {
+            background-color: ${
+              Color(color).isDark() && color !== "transparent"
+                ? "#ffffff"
+                : "#333333"
+            };
+        }
+        
+        .menu-container .menu-item-check, .menu-container .submenu-indicator {
+            background-color: ${
+              Color(color).isDark() && color !== "transparent"
+                ? "#ffffff"
+                : "#333333"
+            };
+        }`;
+
+    if (!styleElement) document.head.appendChild(style);
+
+    document
+      .querySelectorAll<HTMLElement>(".menubar-menu-items-holder")
+      .forEach(menu => {
+        menu.style.backgroundColor =
+          color !== "transparent" ? Color(color).darken(0.12) : "#EDEDED";
+        menu.style.color =
+          Color(color).isDark() && color !== "transparent"
+            ? "#ffffff"
+            : "#333333";
+      });
+  }
 }

--- a/src/icon.ts
+++ b/src/icon.ts
@@ -1,0 +1,48 @@
+import titleBar = require("./titlebar");
+
+/**
+ * It method create icon if icon was setted in options and not null.
+ */
+export function createIcon() {
+  if (
+    titleBar.titleBarOptions.icon === null ||
+    titleBar.titleBarOptions.icon == ""
+  )
+    return;
+
+  let windowIcon: HTMLElement = document.createElement("div");
+  windowIcon.setAttribute("class", "window-appicon");
+  windowIcon.setAttribute("id", "window-appicon");
+
+  windowIcon.style.backgroundImage = `url(${titleBar.titleBarOptions.icon!})`;
+
+  if (titleBar.titleBarOptions.order == "inverted") {
+    windowIcon.style.margin = "0 0 0 auto";
+  } else {
+    windowIcon.style.margin = "0 0 auto";
+  }
+
+  titleBar.titlebarChildren.push(windowIcon);
+}
+
+/**
+ * It method set new icon to title-bar-icon of title-bar.
+ * @param path path to icon.
+ */
+export function setIcon(path: string) {
+  if (path === null || path == "") return;
+
+  if (
+    document.getElementById("window-appicon") === null ||
+    document.getElementById("window-appicon") === undefined
+  ) {
+    console.warn(
+      "Method setIcon must be called after createIcon method! But do not worry, we will call createIcon! But probabli you need re-align title."
+    );
+    titleBar.titleBarOptions.icon = path;
+    createIcon();
+  } else {
+    let icon = document.getElementById("window-appicon")!;
+    icon.style.backgroundImage = `url(${path})`;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./titlebar";
 export * from "./themebar";
 export * from "./title";
 export * from "./icon";
+export * from "./menu";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-export * from './titlebar';
-export * from './themebar';
+export * from "./titlebar";
+export * from "./themebar";
+export * from "./title";
+export * from "./icon";

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,0 +1,324 @@
+import {
+  Event,
+  Menu,
+  MenuItem,
+  MenuItemConstructorOptions,
+  remote
+} from "electron";
+import { GlobalTitlebar } from "./global";
+import { Themebar } from "./index";
+import titleBar = require("./titlebar");
+
+const Color = require("color");
+
+let htmlExtender = new GlobalTitlebar();
+
+/**
+ * It method create menu if menu exists or provided by electron.
+ */
+export function createMenu() {
+  if (titleBar.titleBarOptions.menu) {
+    if (titleBar.titleBarOptions.menuInHeader) {
+      if (
+        titleBar.titleBarOptions.iconsStyle !== Themebar.mac &&
+        titleBar.titleBarOptions.order !== "inverted"
+      ) {
+        if (
+          titleBar.titleBarOptions.icon === null ||
+          titleBar.titleBarOptions.icon == ""
+        ) {
+          titleBar.titlebarChildren.push(
+            htmlExtender.$(".window-menu", {
+              id: "window-menu",
+              style: `padding-left: 10px; width: 100%; height: 30px; line-height: 34px; position: absolute; width: auto; z-index: 101;`
+            })
+          );
+        } else {
+          titleBar.titlebarChildren.push(
+            htmlExtender.$(".window-menu", {
+              id: "window-menu",
+              style: `padding-left: 35px; width: 100%; height: 30px; line-height: 34px; position: absolute; width: auto; z-index: 101;`
+            })
+          );
+        }
+      } else {
+        titleBar.titlebarChildren.push(
+          htmlExtender.$(".window-menu-separator", {
+            style: `background: ${
+              titleBar.titleBarOptions.menuSeparatorColor
+            }; width: 100%; height: 1px; top: 30px; position: absolute;`
+          })
+        );
+        titleBar.titlebarChildren.push(
+          htmlExtender.$(".window-menu", {
+            id: "window-menu",
+            style: `background: ${
+              titleBar.titleBarOptions.menuBackgroundColor
+            }; padding-left: 5px; width: 100%; height: 25px; top: 31px; position: absolute;`
+          })
+        );
+      }
+    } else {
+      titleBar.titlebarChildren.push(
+        htmlExtender.$(".window-menu-separator", {
+          style: `background: ${
+            titleBar.titleBarOptions.menuSeparatorColor
+          }; width: 100%; height: 1px; top: 30px; position: absolute;`
+        })
+      );
+      titleBar.titlebarChildren.push(
+        htmlExtender.$(".window-menu", {
+          id: "window-menu",
+          style: `background: ${
+            titleBar.titleBarOptions.menuBackgroundColor
+          }; padding-left: 5px; width: 100%; height: 25px; top: 31px; position: absolute;`
+        })
+      );
+    }
+  }
+}
+
+/**
+ * Set the menu for the titlebar.
+ */
+export function setMenu(menu: Menu) {
+  const menubar = document.querySelector(".menubar");
+
+  if (menubar) {
+    menubar.innerHTML = "";
+
+    (menu.items as Array<MenuItemConstructorOptions>).forEach(item => {
+      let menuButton = htmlExtender.$(
+        ".menubar-menu-button",
+        {
+          role: "menuitem",
+          "aria-label": cleanMnemonic(`${item.label}`),
+          "aria-keyshortcuts": item.accelerator
+        },
+        getLabelFormat(`${item.label}`)
+      );
+
+      let submenu = item.submenu as Menu;
+      if (submenu && submenu.items.length)
+        createSubmenu(menuButton, submenu.items, false);
+      menubar.appendChild(menuButton);
+    });
+  }
+
+  htmlExtender.setColors(titleBar.backgroundColorGlobal);
+  if (titleBar.titleBarOptions.menuItemHoverColor)
+    setEvents(titleBar.titleBarOptions.menuItemHoverColor);
+}
+
+/**
+ * It method simple clean a menu label.
+ * @param label menu label string what needed to clean.
+ * @returns cleaned menu label string.
+ */
+function cleanMnemonic(label: string): string {
+  const regex = /\(&{1,2}(.)\)|&{1,2}(.)/;
+  const matches = regex.exec(label);
+
+  if (!matches) return label;
+
+  return label.replace(regex, matches[0].charAt(0) === "&" ? "$2" : "").trim();
+}
+
+/**
+ * It method getting menu button label format.
+ * @param label menu button label what needed to format.
+ * @returns formatted label typed as HTMLElement.
+ */
+function getLabelFormat(label: string): HTMLElement {
+  const titleElement = htmlExtender.$(".menubar-menu-title", {
+    "aria-hidden": true
+  });
+  titleElement.innerHTML =
+    label.indexOf("&") !== -1
+      ? label.replace(
+          /\(&{1,2}(.)\)|&{1,2}(.)/,
+          '<mnemonic aria-hidden="true">$2</mnemonic>'
+        )
+      : cleanMnemonic(label);
+
+  return titleElement;
+}
+
+/**
+ * It method set events for menu buttons.
+ */
+function setEvents(hoverColor: string) {
+  let openedMenu: boolean = false;
+  let selectElementMenu: HTMLElement;
+  let pressed = false;
+  const drag = document.querySelector<HTMLElement>(".titlebar-drag-region");
+
+  // Event to menubar items.
+  document
+    .querySelectorAll<HTMLElement>(".menubar-menu-button")
+    .forEach(elem => {
+      elem.addEventListener("click", () => {
+        if (drag && !openedMenu) drag.style.display = "none";
+        if (drag && openedMenu) drag.removeAttribute("style");
+        (elem.lastChild as HTMLElement).style.left = `${
+          elem.getBoundingClientRect().left
+        }px`;
+        elem.classList.toggle("open");
+        selectElementMenu = elem;
+        openedMenu = !openedMenu;
+      });
+
+      elem.addEventListener("mouseover", () => {
+        if (openedMenu) {
+          selectElementMenu.classList.remove("open");
+          (elem.lastChild as HTMLElement).style.left = `${
+            elem.getBoundingClientRect().left
+          }px`;
+          elem.classList.add("open");
+          selectElementMenu = elem;
+        }
+      });
+    });
+
+  // Event to click outside of menu.
+  const container = document.getElementById("content-after-titlebar");
+  if (container)
+    container.addEventListener("click", () => {
+      if (openedMenu) {
+        if (drag) drag.removeAttribute("style");
+        selectElementMenu.classList.remove("open");
+        openedMenu = false;
+      }
+    });
+
+  // Event to menu items.
+  document
+    .querySelectorAll(".menubar .action-item:not(.disable)")
+    .forEach(elem => {
+      elem.addEventListener("mouseover", () => {
+        const contentColor = Color(hoverColor).isDark() ? "#ffffff" : "#333333";
+        (elem.childNodes[0] as HTMLElement).style.backgroundColor = hoverColor;
+        (elem.childNodes[0] as HTMLElement).style.color = contentColor;
+        (elem.childNodes[0]
+          .firstChild as HTMLElement).style.backgroundColor = contentColor;
+        if (
+          !(elem.childNodes[0].lastChild as HTMLElement).classList.contains(
+            "keybinding"
+          )
+        ) {
+          (elem.childNodes[0]
+            .lastChild as HTMLElement).style.backgroundColor = contentColor;
+        }
+
+        if (
+          (elem.childNodes[0].lastChild as HTMLElement).classList.contains(
+            "submenu-indicator"
+          )
+        ) {
+          (elem.lastChild as HTMLElement).style.left = `${
+            elem.getBoundingClientRect().width
+          }px`;
+          (elem.lastChild as HTMLElement).classList.add("open");
+        }
+      });
+
+      elem.addEventListener("mouseleave", () => {
+        (elem.childNodes[0] as HTMLElement).removeAttribute("style");
+        (elem.childNodes[0].firstChild as HTMLElement).removeAttribute("style");
+        (elem.childNodes[0].lastChild as HTMLElement).removeAttribute("style");
+
+        if (
+          (elem.childNodes[0].lastChild as HTMLElement).classList.contains(
+            "submenu-indicator"
+          )
+        ) {
+          (elem.lastChild as HTMLElement).classList.remove("open");
+        }
+      });
+    });
+
+  // Alt key event.
+  document.addEventListener("keydown", event => {
+    pressed = !pressed;
+    document
+      .querySelectorAll<HTMLElement>("mnemonic")
+      .forEach((elem: HTMLElement) => {
+        if (event.altKey)
+          elem.style.textDecoration = pressed ? "underline" : "";
+      });
+  });
+}
+
+/**
+ * It method creating submenu for application menus.
+ */
+function createSubmenu(
+  element: Element,
+  items: Array<MenuItem>,
+  isSubmenu: boolean
+) {
+  let event: Event;
+  const list: Array<Node> = [];
+
+  (items as Array<MenuItemConstructorOptions>).forEach(item => {
+    let child = htmlExtender.$(
+      `li.action-item.${
+        item.type === "separator" || !item.enabled ? "disable" : ""
+      }`
+    );
+
+    if (item.type === "separator") {
+      child.appendChild(
+        htmlExtender.$("a.action-label.icon.separator.disabled")
+      );
+    } else {
+      const children = [
+        htmlExtender.$("span.menu-item-check", { role: "none" }),
+        htmlExtender.$(
+          "span.action-label",
+          { "aria-label": `${item.label}` },
+          getLabelFormat(`${item.label}`)
+        ),
+        item.submenu
+          ? htmlExtender.$("span.submenu-indicator")
+          : htmlExtender.$(
+              "span.keybinding",
+              {},
+              `${item.accelerator ? item.accelerator : ""}`
+            )
+      ];
+      const menuItem = htmlExtender.$(
+        `a.action-menu-item.${item.checked ? "checked" : ""}`,
+        { role: "menuitem", "aria-checked": item.checked },
+        ...children
+      );
+      child.addEventListener("click", () => {
+        if (item.type === "checkbox") {
+          menuItem.setAttribute("aria-checked", `${item.checked}`);
+          menuItem.classList.toggle("checked");
+        }
+        if (item.click)
+          item.click(item as MenuItem, remote.getCurrentWindow(), event);
+      });
+      child.appendChild(menuItem);
+    }
+
+    if (item.submenu || item.type === "submenu") {
+      const submenu = item.submenu as Menu;
+      if (submenu.items.length) createSubmenu(child, submenu.items, true);
+      element.appendChild(child);
+    }
+
+    list.push(child);
+  });
+
+  element.appendChild(
+    htmlExtender.$(
+      `${
+        isSubmenu ? ".submenu.context-view" : ""
+      }.menubar-menu-items-holder.menu-container`,
+      {},
+      htmlExtender.$("ul.actions-container", { role: "menu" }, ...list)
+    )
+  );
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,72 +2,68 @@ import { Menu } from "electron";
 
 export interface TitlebarConstructorOptions {
   /**
-   * The icon shown on the left side of the title bar.
-   */
-  icon?: string;
-  /**
-   * Style of the icons.
-   * You can create your custom style using `HTMLStyleElements`
-   */
-  iconsStyle?: HTMLStyleElement;
-  /**
-   * The shadow of the titlebar.
-   * This property is similar to box-shadow
-   */
-  shadow?: string;
-  /**
-   * The menu to show in the title bar.
-   * You can use `Menu` or not add this option and the menu created in the main process will be taken.
-   */
-  menu?: Menu | null;
-  /**
-   * Define whether or not you can drag the window by holding the click on the title bar.
-   * *The default value is true*
-   */
-  drag?: boolean;
-  /**
-   * Define if the minimize window button is displayed.
-   * *The default value is true*
-   */
-  minimizable?: boolean;
-  /**
-   * Define if the maximize and restore window buttons are displayed.
-   * *The default value is true*
-   */
-  maximizable?: boolean;
-  /**
-   * Define if the close window button is displayed.
-   * *The default value is true*
+   * Define if the close window button is displayed, default value is `true`.
    */
   closeable?: boolean;
   /**
-   * Set the order of the elements on the title bar.
-   * *The default value is normal*
+   * Define whether or not you can drag the window by holding the click on the title bar, default value is `true`.
    */
-  order?: "normal" | "reverse" | "firstButtons";
+  drag?: boolean;
   /**
-   * Set horizontal alignment of the window title.
-   * *The default value is center*
+   * The icon shown on the left side of the title bar. Default value is `null`.
    */
-  titleHorizontalAlignment?: "left" | "center" | "right";
+  icon?: string;
   /**
-   * The background color when the mouse is over the item
+   * Style of the icons. You can create your custom style using `HTMLStyleElements`.
+   * Default value is `Themebar.win`.
    */
-  menuItemHoverColor?: string;
+  iconsStyle?: HTMLStyleElement;
   /**
-   * The background color of menu panel.
+   * Define if the maximize and restore window buttons are displayed, default value is `true`.
+   */
+  maximizable?: boolean;
+  /**
+   * The menu to show in the title bar. if `null` - menu not be displayed.
+   * You can use `Menu` or not add this option and the menu created in the main process will be taken.
+   * Default value `be getted by electron`.
+   */
+  menu?: Menu | null;
+  /**
+   * Menu panel background color, default value is `rgba(0, 0, 0, .08)`.
+   */
+  menuBackgroundColor: string;
+  /**
+   * Position menu, if `true` menu be displayed in header, if false in bottom of title-bar.
+   * Important! True value caused center horizontal align for title, and menu be refresh to `false` if your options order to inverted!
+   * Default value of it property is `false`.
+   */
+  menuInHeader: boolean;
+  /**
+   * Menu button hover color, default value is `rgba(0, 0, 0, .14)`.
+   */
+  menuItemHoverColor: string;
+  /**
+   * Menu separator color, default value is `rgba(0, 0, 0, .29)`.
+   */
+  menuSeparatorColor: string;
+  /**
+   * Define if the minimize window button is displayed, default value is `true`.
+   */
+  minimizable?: boolean;
+  /**
+   * Order of the elements on the title bar, default value is `default`.
    */
   menuBackgroundColor?: string;
   /**
-   * The color of menu separator.
+   * The shadow of the titlebar. This property is similar to box-shadow.
    */
-  menuSeparatorColor?: string;
+  shadow?: string;
   /**
-   * Menu padding from left window border.
+   * Horizontal alignment of the window title, default value is `center`.
    */
-  menuLeftPadding?: string;
+  titleHorizontalAlignment: "left" | "center" | "right";
   /**
-   * Menu direction, supported left and right.
+   * Title text visibility, if `true` - title not be displayed in title-bar and not be created, default value is `true`.
    */
-  menuDirection: "left" | "right";
+  titleVisibility: boolean;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -66,4 +66,8 @@ export interface TitlebarConstructorOptions {
    * Menu padding from left window border.
    */
   menuLeftPadding?: string;
+  /**
+   * Menu direction, supported left and right.
+   */
+  menuDirection: "left" | "right";
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -54,4 +54,16 @@ export interface TitlebarConstructorOptions {
    * The background color when the mouse is over the item
    */
   menuItemHoverColor?: string;
+  /**
+   * The background color of menu panel.
+   */
+  menuBackgroundColor?: string;
+  /**
+   * The color of menu separator.
+   */
+  menuSeparatorColor?: string;
+  /**
+   * Menu padding from left window border.
+   */
+  menuLeftPadding?: string;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -53,7 +53,7 @@ export interface TitlebarConstructorOptions {
   /**
    * Order of the elements on the title bar, default value is `default`.
    */
-  menuBackgroundColor?: string;
+  order: "default" | "inverted";
   /**
    * The shadow of the titlebar. This property is similar to box-shadow.
    */

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -54,8 +54,7 @@
     flex-grow: 0;
     flex-shrink: 0;
     text-align: center;
-    position: relative;
-    z-index: 99;
+    z-index: 100;
     -webkit-app-region: no-drag;
     height: 100%;
     margin-left: 5px;

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -2,7 +2,7 @@
 .titlebar {
   position: absolute;
   top: 0;
-  left:0;
+  left: 0;
   right: 0;
 	box-sizing: border-box;
 	width: 100%;

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -3,32 +3,32 @@
   top: 0;
   left: 0;
   right: 0;
-	box-sizing: border-box;
-	width: 100%;
-	font-size: 13px;
-	padding: 0 70px;
-	overflow: hidden;
-	flex-shrink: 0;
-	align-items: center;
-	justify-content: center;
-	user-select: none;
-	zoom: 1;
-	line-height: 22px;
-	height: 22px;
-	display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  font-size: 13px;
+  padding: 0 70px;
+  overflow: hidden;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  zoom: 1;
+  line-height: 22px;
+  height: 22px;
+  display: flex;
 
-	.titlebar-drag-region {
-		top: 0;
-		left: 0;
-		display: block;
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		z-index: -1;
-		-webkit-app-region: drag;
-	}
-	
-	.window-title {
+  .titlebar-drag-region {
+    top: 0;
+    left: 0;
+    display: block;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    -webkit-app-region: drag;
+  }
+
+  .window-title {
     font-size: 12px;
     display: inline-block;
     vertical-align: middle;
@@ -75,27 +75,30 @@
   }
 }
 
-.windows .titlebar, .linux .titlebar {
-	padding: 0;
-	height: 30px;
-	line-height: 30px;
-	justify-content: left;
-	overflow: visible;
-	
-	.window-title {
-		cursor: default;
-	}
+.windows .titlebar,
+.linux .titlebar {
+  padding: 0;
+  height: 30px;
+  line-height: 30px;
+  justify-content: left;
+  overflow: visible;
 
-	.resizer {
-		-webkit-app-region: no-drag;
-		position: absolute;
-		top: 0;
-		width: 100%;
-		height: 20%;
+  .window-title {
+    cursor: default;
   }
-  
+
+  .resizer {
+    -webkit-app-region: no-drag;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 20%;
+  }
+
   &.fullscreen {
-    .resizer, .window-appicon, .window-controls-container {
+    .resizer,
+    .window-appicon,
+    .window-controls-container {
       display: none;
     }
 
@@ -107,27 +110,27 @@
 }
 
 .linux .titlebar .window-title {
-	font-size: inherit;
+  font-size: inherit;
 }
 
 /* Menubar */
 .menubar {
-	display: flex;
-	flex-shrink: 1;
-	box-sizing: border-box;
-	height: 30px;
-	-webkit-app-region: no-drag;
-	overflow: hidden;
-	flex-wrap: wrap;
+  display: flex;
+  flex-shrink: 1;
+  box-sizing: border-box;
+  height: 30px;
+  -webkit-app-region: no-drag;
+  overflow: hidden;
+  flex-wrap: wrap;
   margin: 0 5px 0 0;
-  
+
   .menubar-menu-button {
     align-items: center;
     box-sizing: border-box;
     padding: 0 8px;
     cursor: default;
     -webkit-app-region: no-drag;
-    zoom:1;
+    zoom: 1;
     white-space: nowrap;
     outline: 0;
 
@@ -135,26 +138,27 @@
       display: block;
     }
 
-    &.open, &:hover {
+    &.open,
+    &:hover {
       background-color: rgba(255, 255, 255, 0.1);
     }
   }
 }
 
 .menubar-menu-items-holder {
-	display: none;
-	position: absolute;
-	left: 0;
-	padding: 0.5em 0;
-	opacity: 1;
-	box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.16);
+  display: none;
+  position: absolute;
+  left: 0;
+  padding: 0.5em 0;
+  opacity: 1;
+  box-shadow: 1px 2px 4px rgba(0, 0, 0, 0.16);
   z-index: 2000;
 
   &.menu-container {
     outline: 0;
     border: none;
     margin-left: 0;
-  	overflow: visible;
+    overflow: visible;
 
     .actions-container {
       display: block;
@@ -176,8 +180,10 @@
       .menu-item-check {
         position: absolute;
         visibility: hidden;
-        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='-2 -2 16 16'%3E%3Cpath fill='%23424242' d='M9 0L4.5 9 3 6H0l3 6h3l6-12z'/%3E%3C/svg%3E") no-repeat 50% 56%/15px 15px;
-        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='-2 -2 16 16'%3E%3Cpath fill='%23424242' d='M9 0L4.5 9 3 6H0l3 6h3l6-12z'/%3E%3C/svg%3E") no-repeat 50% 56%/15px 15px;
+        -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='-2 -2 16 16'%3E%3Cpath fill='%23424242' d='M9 0L4.5 9 3 6H0l3 6h3l6-12z'/%3E%3C/svg%3E")
+          no-repeat 50% 56%/15px 15px;
+        mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='-2 -2 16 16'%3E%3Cpath fill='%23424242' d='M9 0L4.5 9 3 6H0l3 6h3l6-12z'/%3E%3C/svg%3E")
+          no-repeat 50% 56%/15px 15px;
         width: 2em;
         height: 100%;
       }
@@ -194,10 +200,11 @@
       display: flex;
       position: static;
       overflow: visible;
-      
+
       &.disabled {
-        .keybinding, .submenu-indicator {
-          opacity: .4;
+        .keybinding,
+        .submenu-indicator {
+          opacity: 0.4;
         }
       }
 
@@ -222,12 +229,12 @@
       &.separator {
         display: block;
         border-bottom: 1px solid #bbb;
-        margin-left: .8em;
-        margin-right: .8em;
-        padding: .5em 0 0;
-        margin-bottom: .5em;
+        margin-left: 0.8em;
+        margin-right: 0.8em;
+        padding: 0.5em 0 0;
+        margin-bottom: 0.5em;
         width: 100%;
-        opacity: .4;
+        opacity: 0.4;
       }
     }
 
@@ -248,31 +255,34 @@
     .submenu-indicator {
       @extend %keybinding;
       height: 100%;
-      -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.52 12.364L9.879 7 4.52 1.636l.615-.615L11.122 7l-5.986 5.98-.615-.616z' fill='%23000'/%3E%3C/svg%3E") no-repeat 90% 50%/13px 13px;
-      mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.52 12.364L9.879 7 4.52 1.636l.615-.615L11.122 7l-5.986 5.98-.615-.616z' fill='%23000'/%3E%3C/svg%3E") no-repeat 90% 50%/13px 13px;
+      -webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.52 12.364L9.879 7 4.52 1.636l.615-.615L11.122 7l-5.986 5.98-.615-.616z' fill='%23000'/%3E%3C/svg%3E")
+        no-repeat 90% 50%/13px 13px;
+      mask: url("data:image/svg+xml;charset=utf-8,%3Csvg width='14' height='14' viewBox='0 0 14 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.52 12.364L9.879 7 4.52 1.636l.615-.615L11.122 7l-5.986 5.98-.615-.616z' fill='%23000'/%3E%3C/svg%3E")
+        no-repeat 90% 50%/13px 13px;
     }
   }
-  
+
   &.submenu {
     display: none;
   }
 }
 
 %label_keybinding {
-	font-size: inherit;
-	padding: 0 2em;
+  font-size: inherit;
+  padding: 0 2em;
 }
 
 %keybinding {
-	display: inline-block;
-	-ms-flex: 2 1 auto;
-	flex: 2 1 auto;
-	padding: 0 1em;
-	text-align: right;
-	font-size: 12px;
-	line-height: 1;
+  display: inline-block;
+  -ms-flex: 2 1 auto;
+  flex: 2 1 auto;
+  padding: 0 1em;
+  text-align: right;
+  font-size: 12px;
+  line-height: 1;
 }
 
-.titlebar.light .menubar .menubar-menu-button:hover, .titlebar.light .menubar .menubar-menu-button.open {
-	background-color: rgba(0, 0, 0, 0.1);
+.titlebar.light .menubar .menubar-menu-button:hover,
+.titlebar.light .menubar .menubar-menu-button.open {
+  background-color: rgba(0, 0, 0, 0.1);
 }

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -37,7 +37,18 @@
     z-index: 99;
     width: 100%;
   }
-  
+
+  .window-appicon {
+    width: 35px;
+    height: 100%;
+    position: relative;
+    z-index: 99;
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: 16px;
+    flex-shrink: 0;
+  }
+
   .window-controls-container {
     display: flex;
     flex-grow: 0;

--- a/src/sass/titlebar.scss
+++ b/src/sass/titlebar.scss
@@ -1,4 +1,3 @@
-/* Titlebar */
 .titlebar {
   position: absolute;
   top: 0;
@@ -30,14 +29,13 @@
 	}
 	
 	.window-title {
-		flex: 0 1 auto;
-		font-size: 12px;
-		overflow: hidden;
-		white-space: nowrap;
-		text-overflow: ellipsis;
-		padding-top: 3px;
-		width: 100%;
-		zoom: 1;
+    font-size: 12px;
+    display: inline-block;
+    vertical-align: middle;
+    padding-top: 3px;
+    line-height: normal;
+    z-index: 99;
+    width: 100%;
   }
   
   .window-controls-container {

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,0 +1,101 @@
+import { Themebar } from "./index";
+import titleBar = require("./titlebar");
+
+/**
+ * It method create title if title visibility true, also set initial text as document.title.
+ */
+export function createTitle() {
+  if (!titleBar.titleBarOptions.titleVisibility) return;
+
+  let windowTitle: HTMLElement = document.createElement("div");
+  windowTitle.setAttribute("class", "window-title");
+  windowTitle.setAttribute("id", "window-title");
+  windowTitle.innerText = document.title;
+
+  titleBar.titlebarChildren.push(windowTitle);
+}
+
+/**
+ * Update the title of the title bar.
+ * You can use this method if change the content of `<title>` tag on your html
+ * Or you can just call it method without args, default value is document title
+ * @param text The title of the title bar and document
+ */
+export function setTitleText(text: string) {
+  if (!titleBar.titleBarOptions.titleVisibility) return;
+
+  let windowTitle: HTMLElement = getTitleInDocument();
+  windowTitle.innerText = text;
+}
+
+/**
+ * It method set title horizontal alignment of title-bar.
+ * @param alignment side of title-bar, available values: (left, center, right).
+ */
+export function setHorizontalAlignment(alignment: string) {
+  if (!titleBar.titleBarOptions.titleVisibility) return;
+
+  let windowTitle: HTMLElement = getTitleInDocument();
+  windowTitle.style.position = "absolute";
+
+  if (titleBar.titleBarOptions.menuInHeader) {
+    if (
+      titleBar.titleBarOptions.iconsStyle !== Themebar.mac &&
+      titleBar.titleBarOptions.order !== "inverted"
+    ) {
+      windowTitle.style.textAlign = "center";
+      return;
+    }
+  }
+
+  if (alignment == "left") {
+    windowTitle.style.textAlign = "left";
+
+    if (titleBar.titleBarOptions.order == "inverted") {
+      if (titleBar.titleBarOptions.iconsStyle == Themebar.mac) {
+        windowTitle.style.paddingLeft = "95px";
+      } else {
+        windowTitle.style.paddingLeft = "150px";
+      }
+    } else {
+      if (
+        titleBar.titleBarOptions.icon === null ||
+        titleBar.titleBarOptions.icon == ""
+      ) {
+        windowTitle.style.paddingLeft = "15px";
+      } else {
+        windowTitle.style.paddingLeft = "35px";
+      }
+    }
+  } else if (alignment == "right") {
+    windowTitle.style.textAlign = "right";
+
+    if (titleBar.titleBarOptions.order == "inverted") {
+      if (
+        titleBar.titleBarOptions.icon === null ||
+        titleBar.titleBarOptions.icon == ""
+      ) {
+        windowTitle.style.paddingRight = "15px";
+      } else {
+        windowTitle.style.paddingRight = "35px";
+      }
+    } else {
+      if (titleBar.titleBarOptions.iconsStyle == Themebar.mac) {
+        windowTitle.style.paddingRight = "95px";
+      } else {
+        windowTitle.style.paddingRight = "150px";
+      }
+    }
+  } else if (alignment == "center") {
+    windowTitle.style.textAlign = "center";
+  } else {
+    console.warn(
+      `Method setHorizontalAlignment have argument what must contains side ( left, center, right ), your argument '${alignment}' not correct, so title was initialized with center alignment!`
+    );
+    windowTitle.style.textAlign = "center";
+  }
+}
+
+function getTitleInDocument(): HTMLElement {
+  return document.getElementById("window-title")!;
+}

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -22,6 +22,9 @@ export class Titlebar extends GlobalTitlebar {
     closeable: true,
     order: 'normal',
     menuItemHoverColor: 'rgba(0, 0, 0, .14)',
+    menuBackgroundColor: 'rgba(0, 0, 0, .08)',
+    menuSeparatorColor: 'rgba(0, 0, 0, .29)',
+    menuLeftPadding: '5px',
     titleHorizontalAlignment: 'center'
   };
 
@@ -48,10 +51,16 @@ export class Titlebar extends GlobalTitlebar {
 
   private createTitleBar(): void {
     let titlebarChildren: Node[] = [];
+    let div;
 
     document.body.classList.add(platform == 'win32' ? 'windows' : platform == 'linux' ? 'linux' : 'mac');
     
-    let div = this.$('#content-after-titlebar', { 'style': 'top:30px;right:0;bottom:0;left:0;position:absolute;overflow:auto;' });
+    if (this.options.menu !== null) {
+      div = this.$('#content-after-titlebar', { 'style': 'top:56px; right:0; bottom:0; left:0; position:absolute; overflow:auto;' });
+    } else {
+      div = this.$('#content-after-titlebar', { 'style': 'top:30px; right:0; bottom:0; left:0; position:absolute; overflow:auto;' });
+    }
+
     while (document.body.firstChild) div.appendChild(document.body.firstChild);
     document.body.appendChild(div);
     
@@ -82,7 +91,8 @@ export class Titlebar extends GlobalTitlebar {
     }
 
     if (this.options.menu) {
-      titlebarChildren.push(this.$('.menubar', { 'role': 'menubar' }));
+      titlebarChildren.push(this.$('.window-menu-separator', { 'style': `background: ${this.options.menuSeparatorColor}; width: 100%; height: 1px; top: 30px; position: absolute;` }))
+      titlebarChildren.push(this.$('.window-menu', { 'id': 'window-menu', 'style': `background: ${this.options.menuBackgroundColor}; padding-left: ${this.options.menuLeftPadding}; width: 100%; height: 25px; top: 31px; position: absolute;` }))
     }
 
     if (platform !== 'darwin') {
@@ -105,7 +115,10 @@ export class Titlebar extends GlobalTitlebar {
         ...titlebarChildren)
     );
 
-    if (this.options.menu) this.setMenu(this.options.menu);
+    if (this.options.menu) {
+      document.getElementById("window-menu")!.appendChild(this.$('.menubar', { 'role': 'menubar' }))
+      this.setMenu(this.options.menu);
+    }
   }
 
   private setStyles(): void {

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -1,140 +1,171 @@
-import { remote, BrowserWindow, Menu, MenuItem, MenuItemConstructorOptions, Event } from 'electron';
-import * as path from 'path';
-import * as fs from 'fs';
-import { platform } from 'process';
-import { Themebar } from './index';
-import { TitlebarConstructorOptions } from './options';
-import { GlobalTitlebar } from './global';
+import * as fs from "fs";
+import * as path from "path";
+import { BrowserWindow, remote } from "electron";
+import { createIcon, setIcon } from "./icon";
+import { createMenu, setMenu } from "./menu";
+import { createTitle, setHorizontalAlignment, setTitleText } from "./title";
+import { GlobalTitlebar } from "./global";
+import { platform } from "process";
+import { Themebar } from "./index";
+import { TitlebarConstructorOptions } from "./options";
 
-const Color = require('color');
-const allowAlign = ['left', 'center', 'right'];
+export let titlebarChildren: Node[] = [];
+export let titleBarOptions: TitlebarConstructorOptions;
+export let baseDiv: HTMLElement;
+export let backgroundColorGlobal: string;
+
+const Color = require("color");
 
 export class Titlebar extends GlobalTitlebar {
   private currentWindow: BrowserWindow;
 
-  private defaultOptions: TitlebarConstructorOptions = {
-    icon: '',
-    iconsStyle: Themebar.win,
-    menu: remote.Menu.getApplicationMenu(),
-    drag: true,
-    minimizable: true,
-    maximizable: true,
+  defaultOptions: TitlebarConstructorOptions = {
     closeable: true,
-    order: 'normal',
-    menuItemHoverColor: 'rgba(0, 0, 0, .14)',
-    menuBackgroundColor: 'rgba(0, 0, 0, .08)',
-    menuSeparatorColor: 'rgba(0, 0, 0, .29)',
-    menuLeftPadding: '5px',
-    menuDirection: 'left',
-    titleHorizontalAlignment: 'center'
+    drag: true,
+    icon: "",
+    iconsStyle: Themebar.win,
+    maximizable: true,
+    menu: remote.Menu.getApplicationMenu(),
+    menuBackgroundColor: "rgba(0, 0, 0, .08)",
+    menuInHeader: false,
+    menuItemHoverColor: "rgba(0, 0, 0, .14)",
+    menuSeparatorColor: "rgba(0, 0, 0, .29)",
+    minimizable: true,
+    order: "default",
+    titleHorizontalAlignment: "center",
+    titleVisibility: true
   };
 
-  /**
-   * Background color of the title bar
-   */
-  backgroundColor: string;
-  /**
-   * Options of the title bar
-   */
   options: TitlebarConstructorOptions;
 
   constructor(backgroundColor: string, options?: TitlebarConstructorOptions) {
     super();
     this.currentWindow = remote.getCurrentWindow();
-    this.backgroundColor = backgroundColor;
-    this.options = {...this.defaultOptions, ...options};
+    backgroundColorGlobal = backgroundColor;
+    this.options = { ...this.defaultOptions, ...options };
+    titleBarOptions = this.options;
 
     this.createTitleBar();
-    this.setStyles();
+    createTitle();
+    createIcon();
+    createMenu();
+    this.applyChildren();
+    this.applyStyles();
+    this.applyMenuBar();
     this.addEvents();
-    this.updateTitle();
   }
 
-  private createTitleBar(): void {
-    let titlebarChildren: Node[] = [];
-    let div;
-
-    document.body.classList.add(platform == 'win32' ? 'windows' : platform == 'linux' ? 'linux' : 'mac');
-    
-    if (this.options.menu !== null) {
-      div = this.$('#content-after-titlebar', { 'style': 'top:56px; right:0; bottom:0; left:0; position:absolute; overflow:auto;' });
-    } else {
-      div = this.$('#content-after-titlebar', { 'style': 'top:30px; right:0; bottom:0; left:0; position:absolute; overflow:auto;' });
-    }
-
-    while (document.body.firstChild) div.appendChild(document.body.firstChild);
-    document.body.appendChild(div);
-    
-    if (this.options.drag) {
-      titlebarChildren.push(this.$('.titlebar-drag-region'));
-    }
-
-    titlebarChildren.push(this.$('.window-appicon'));
-
-    if (allowAlign.some(x => x === this.options.titleHorizontalAlignment)) {
-      if (this.options.icon === null) {
-        if (this.options.titleHorizontalAlignment == 'left' && this.options.order !== "reverse") {
-          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: left; padding-left: 15px` }))
-        } else if (this.options.titleHorizontalAlignment == 'right' && this.options.order == "reverse" || this.options.order == "firstButtons") {
-          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: right; padding-right: 15px` }))
-        } else {
-          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: ${this.options.titleHorizontalAlignment};` }))
-        }
-      } else {
-        if (this.options.titleHorizontalAlignment == 'right' && this.options.order == "firstButtons") {
-          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: right; padding-right: 15px` }))
-        } else {
-          titlebarChildren.push(this.$('.window-title', { 'style': `text-align: ${this.options.titleHorizontalAlignment};` }))
-        }
-      }
-    } else {
-      titlebarChildren.push(this.$('.window-title', { 'style': 'text-align: center;' }))
-    }
-
-    if (this.options.menu) {
-      let direction = this.getDirection(this.options.menuDirection);
-      titlebarChildren.push(this.$('.window-menu-separator', { 'style': `background: ${this.options.menuSeparatorColor}; width: 100%; height: 1px; top: 30px; position: absolute;` }))
-      titlebarChildren.push(this.$('.window-menu', { 'id': 'window-menu', 'style': `background: ${this.options.menuBackgroundColor}; padding-left: ${this.options.menuLeftPadding}; width: 100%; height: 25px; top: 31px; position: absolute; direction: ${direction};` }))
-    }
-
-    if (platform !== 'darwin') {
-      titlebarChildren.push(this.$('.window-controls-container', {},
-        ...[
-          this.$(`.window-icon-bg${!this.options.minimizable ? '.inactive' : ''}`, {}, this.$('.window-icon.window-minimize')),
-          this.$(`.window-icon-bg${!this.options.maximizable ? '.inactive' : ''}`, {},
-            this.$(`.window-icon ${this.currentWindow.isMaximized() ? 'window-unmaximize' : 'window-maximize'}`)
-          ),
-          this.$(`.window-icon-bg.window-close-bg${!this.options.closeable ? '.inactive' : ''}`, {}, this.$('.window-icon.window-close'))
-        ]
-      ));
-    }
-
-    titlebarChildren.push(this.$('.resizer', { 'style': `display:${this.currentWindow.isMaximized() ? 'none': 'block'}` }));
-
-    document.body.prepend(
-      this.$(`#titlebar.titlebar.${this.options.order}`,
-        this.options.shadow ? { 'style': `box-shadow:${this.options.shadow};` } : {},
-        ...titlebarChildren)
+  private createTitleBar() {
+    document.body.classList.add(
+      platform == "win32" ? "windows" : platform == "linux" ? "linux" : "mac"
     );
 
-    if (this.options.menu) {
-      document.getElementById("window-menu")!.appendChild(this.$('.menubar', { 'role': 'menubar' }))
-      this.setMenu(this.options.menu);
-    }
-  }
-
-  private getDirection(rawString: string): string {
-    if (rawString == "right") {
-      return "rtl"
+    if (this.options.menu !== null) {
+      if (this.options.menuInHeader) {
+        if (
+          this.options.iconsStyle !== Themebar.mac &&
+          this.options.order !== "inverted"
+        ) {
+          baseDiv = this.$("#content-after-titlebar", {
+            style:
+              "top:30px; right:0; bottom:0; left:0; position:absolute; overflow:auto;"
+          });
+        } else {
+          baseDiv = this.$("#content-after-titlebar", {
+            style:
+              "top:56px; right:0; bottom:0; left:0; position:absolute; overflow:auto;"
+          });
+        }
+      } else {
+        baseDiv = this.$("#content-after-titlebar", {
+          style:
+            "top:56px; right:0; bottom:0; left:0; position:absolute; overflow:auto;"
+        });
+      }
     } else {
-      return "ltr"
+      baseDiv = this.$("#content-after-titlebar", {
+        style:
+          "top:30px; right:0; bottom:0; left:0; position:absolute; overflow:auto;"
+      });
+    }
+
+    if (this.options.drag) {
+      titlebarChildren.push(this.$(".titlebar-drag-region"));
+    }
+
+    titlebarChildren.push(
+      this.$(".resizer", {
+        style: `display:${this.currentWindow.isMaximized() ? "none" : "block"}`
+      })
+    );
+
+    while (document.body.firstChild)
+      baseDiv.appendChild(document.body.firstChild);
+    document.body.appendChild(baseDiv);
+
+    if (platform !== "darwin") {
+      titlebarChildren.push(
+        this.$(
+          ".window-controls-container",
+          { style: this.getWindowControlsOrder() },
+          ...[
+            this.$(
+              `.window-icon-bg${!this.options.minimizable ? ".inactive" : ""}`,
+              {},
+              this.$(".window-icon.window-minimize")
+            ),
+            this.$(
+              `.window-icon-bg${!this.options.maximizable ? ".inactive" : ""}`,
+              {},
+              this.$(
+                `.window-icon ${
+                  this.currentWindow.isMaximized()
+                    ? "window-unmaximize"
+                    : "window-maximize"
+                }`
+              )
+            ),
+            this.$(
+              `.window-icon-bg.window-close-bg${
+                !this.options.closeable ? ".inactive" : ""
+              }`,
+              {},
+              this.$(".window-icon.window-close")
+            )
+          ]
+        )
+      );
     }
   }
 
-  private setStyles(): void {
-    document.head.appendChild(this.$('style.titlebar-style', {}, `
-      ${fs.readFileSync(path.resolve(path.resolve(path.dirname(require.resolve('./index')), 'css'), 'titlebar.css'), 'utf8')}
-      ${this.options.icon ? `.titlebar > .window-appicon {
+  private applyChildren() {
+    document.body.prepend(
+      this.$(
+        `#titlebar.titlebar.${this.options.order}`,
+        this.options.shadow
+          ? { style: `box-shadow:${this.options.shadow};` }
+          : {},
+        ...titlebarChildren
+      )
+    );
+  }
+
+  private applyStyles() {
+    document.head.appendChild(
+      this.$(
+        "style.titlebar-style",
+        {},
+        `
+      ${fs.readFileSync(
+        path.resolve(
+          path.resolve(path.dirname(require.resolve("./index")), "css"),
+          "titlebar.css"
+        ),
+        "utf8"
+      )}
+      ${
+        this.options.icon
+          ? `.titlebar > .window-appicon {
         width: 35px;
         height: 100%;
         position: relative;
@@ -144,97 +175,110 @@ export class Titlebar extends GlobalTitlebar {
         background-position: center center;
         background-size: 16px;
         flex-shrink: 0;
-      }` : ''}
-    `));
+      }`
+          : ""
+      }
+    `
+      )
+    );
 
-    this.setBackground(this.backgroundColor);
+    this.setBackground(backgroundColorGlobal);
     if (this.options.iconsStyle) this.setThemeIcons(this.options.iconsStyle);
 
-    document.body.style.margin = '0';
-    document.body.style.overflow = 'hidden';
+    document.body.style.margin = "0";
+    document.body.style.overflow = "hidden";
 
-    if(this.currentWindow.isFullScreen) document.body.classList.add('fullscreen');
+    if (this.currentWindow.isFullScreen)
+      document.body.classList.add("fullscreen");
+
+    setHorizontalAlignment(this.options.titleHorizontalAlignment);
   }
 
-  private addEvents(): void {
-    // Minimize button
-    const minimizeButton = document.querySelector('.window-minimize');
-    if(minimizeButton && this.options.minimizable) minimizeButton.addEventListener('click', () => {
-      this.currentWindow.minimize();
-    });
+  private applyMenuBar() {
+    if (this.options.menu) {
+      document
+        .getElementById("window-menu")!
+        .appendChild(this.$(".menubar", { role: "menubar" }));
+      setMenu(this.options.menu);
+    }
+  }
 
-    // Maximize and Unmaximize button
-    document.querySelectorAll('.window-maximize, .window-unmaximize').forEach((elem: Element) => {
-      if(this.options.maximizable) elem.addEventListener('click', () => {
-        if(!this.currentWindow.isMaximized()) this.currentWindow.maximize();
-        else this.currentWindow.unmaximize();
+  private addEvents() {
+    const minimizeButton = document.querySelector(".window-minimize");
+    const closeButton = document.querySelector(".window-close");
+
+    if (minimizeButton && this.options.minimizable)
+      minimizeButton.addEventListener("click", () => {
+        this.currentWindow.minimize();
       });
+
+    if (closeButton && this.options.closeable)
+      closeButton.addEventListener("click", () => {
+        this.currentWindow.close();
+      });
+
+    document
+      .querySelectorAll(".window-maximize, .window-unmaximize")
+      .forEach((elem: Element) => {
+        if (this.options.maximizable)
+          elem.addEventListener("click", () => {
+            if (!this.currentWindow.isMaximized())
+              this.currentWindow.maximize();
+            else this.currentWindow.unmaximize();
+          });
+      });
+
+    this.currentWindow.on("maximize", () => {
+      showHide(".window-maximize", false);
     });
 
-    // Close button
-    const closeButton = document.querySelector('.window-close');
-    if(closeButton && this.options.closeable) closeButton.addEventListener('click', () => {
-      this.currentWindow.close();
+    this.currentWindow.on("unmaximize", () => {
+      showHide(".window-unmaximize", true);
     });
 
-    this.currentWindow.on('maximize', () => {
-      showHide('.window-maximize', false);
-    });
+    this.currentWindow.on("blur", () => {
+      const titlebar = document.getElementById("titlebar");
 
-    this.currentWindow.on('unmaximize', () => {
-      showHide('.window-unmaximize', true);
-    });
-
-    this.currentWindow.on('blur', () => {
-      const titlebar = document.getElementById('titlebar');
-
-      if(titlebar) {
-        titlebar.style.backgroundColor = Color(titlebar.style.backgroundColor).alpha(0.9);
+      if (titlebar) {
+        titlebar.style.backgroundColor = Color(
+          titlebar.style.backgroundColor
+        ).alpha(0.9);
         titlebar.style.color = Color(titlebar.style.color).alpha(0.9);
       }
     });
 
-    this.currentWindow.on('focus', () => {
-      this.setBackground(this.backgroundColor);
+    this.currentWindow.on("focus", () => {
+      this.setBackground(backgroundColorGlobal);
     });
 
-    this.currentWindow.on('enter-full-screen', () => {
-      document.body.classList.add('fullscreen');
+    this.currentWindow.on("enter-full-screen", () => {
+      document.body.classList.add("fullscreen");
     });
 
-    this.currentWindow.on('leave-full-screen', () => {
-      document.body.classList.remove('fullscreen');
+    this.currentWindow.on("leave-full-screen", () => {
+      document.body.classList.remove("fullscreen");
     });
-  }
-
-  /**
-   * Update the title of the title bar.
-   * You can use this method if change the content of `<title>` tag on your html
-   * @param title The title of the title bar and document
-   */
-  updateTitle(title?: string): void {
-    const wTitle = document.querySelector('.window-title');
-    
-    if(title) document.title = title;
-    if(wTitle) wTitle.innerHTML = document.title;
   }
 
   /**
    * Change the background color of the title bar
    * @param color The color for the background
    */
-  setBackground(color: string): void {
-    this.backgroundColor = color;
-    const titlebar = document.getElementById('titlebar');
+  private setBackground(color: string) {
+    const titlebar = document.getElementById("titlebar");
+    backgroundColorGlobal = color;
 
     if (titlebar) {
       titlebar.style.backgroundColor = color;
-      titlebar.style.color = Color(color).isDark() && color !== 'transparent' ? '#ffffff' : '#333333';;
+      titlebar.style.color =
+        Color(color).isDark() && color !== "transparent"
+          ? "#ffffff"
+          : "#333333";
 
-      if (!Color(color).isDark() || color === 'transparent') {
-        titlebar.classList.add('light');
+      if (!Color(color).isDark() || color === "transparent") {
+        titlebar.classList.add("light");
       } else {
-        titlebar.classList.remove('light');
+        titlebar.classList.remove("light");
       }
     }
 
@@ -242,230 +286,72 @@ export class Titlebar extends GlobalTitlebar {
   }
 
   /**
-   * Set the menu for the titlebar
+   * It method set theme for icons of the title-bar.
+   * @param theme icons theme of title-bar, available values: (Themebar.mac, Themebar.win).
    */
-  setMenu(menu: Menu): void {
-    const menubar = document.querySelector('.menubar');
+  private setThemeIcons(theme: HTMLStyleElement) {
+    const currentTheme = document.querySelector("#icons-style");
 
-    if (menubar) {
-      menubar.innerHTML = '';
-
-      (menu.items as Array<MenuItemConstructorOptions>).forEach(item => {
-        let menuButton = this.$('.menubar-menu-button', {
-          'role': 'menuitem',
-          'aria-label': cleanMnemonic(`${item.label}`),
-          'aria-keyshortcuts': item.accelerator
-        }, this.getLabelFormat(`${item.label}`));
-        
-        let submenu = item.submenu as Menu;
-        if (submenu && submenu.items.length) this.createSubmenu(menuButton, submenu.items, false);
-        menubar.appendChild(menuButton);
-      });
-    }
-
-    this.setColors(this.backgroundColor);
-
-    if(this.options.menuItemHoverColor) setEvents(this.options.menuItemHoverColor);
-  }
-
-  /**
-   * set theme for the icons of the title bar
-   */
-  setThemeIcons(theme: HTMLStyleElement): void {
-    const currentTheme = document.querySelector('#icons-style');
-    if(currentTheme) {
+    if (currentTheme) {
       currentTheme.textContent = theme.textContent;
     } else {
-      const newTheme = this.$('style#icons-style');
+      const newTheme = this.$("style#icons-style");
       newTheme.textContent = theme.textContent;
       document.head.appendChild(newTheme);
     }
   }
 
   /**
-  * set horizontal alignment of the window title
-  */
-  setHorizontalAlignment(side: String) {
-    const wTitle = document.querySelector(".window-title") as HTMLElement;
-
-    if (wTitle) {
-      if (allowAlign.some(x => x === side)) {
-        if (this.options.icon === null) {
-          if (side == "left" && this.options.order !== "reverse") {
-            wTitle.style.textAlign = "left";
-            wTitle.style.paddingLeft = "15px";
-          } else if ((side == "right" && this.options.order == "reverse") || this.options.order == "firstButtons") {
-            wTitle.style.textAlign = "right";
-            wTitle.style.paddingRight = "15px";
-          } else {
-            wTitle.style.textAlign = String(side);
-          }
-        } else {
-          if (this.options.titleHorizontalAlignment == "right" && this.options.order == "firstButtons") {
-            wTitle.style.textAlign = "right";
-            wTitle.style.paddingRight = "15px";
-          } else {
-            wTitle.style.textAlign = String(side);
-          }
-        }
-      } else {
-        wTitle.style.textAlign = "center";
-      }
-    }
+   * It method set new icon to title-bar-icon of title-bar.
+   * @param path path to icon.
+   */
+  setIcon(path: string) {
+    setIcon(path);
   }
 
   /**
-   * Format a label
-   * @param label Label to format
+   * Update the title of the title bar.
+   * You can use this method if change the content of `<title>` tag on your html
+   * Or you can just call it method without args, default value is document title
+   * @param title The title of the title bar and document
    */
-  private getLabelFormat(label: string): HTMLElement {
-    const titleElement = this.$('.menubar-menu-title', { 'aria-hidden': true });
-    titleElement.innerHTML = label.indexOf('&') !== -1 ?
-      label.replace(/\(&{1,2}(.)\)|&{1,2}(.)/, '<mnemonic aria-hidden="true">$2</mnemonic>') :
-      cleanMnemonic(label);
-    
-    return titleElement;
+  setTitleText(title: string = document.title) {
+    setTitleText(title);
   }
 
-  private createSubmenu(element: Element, items: Array<MenuItem>, isSubmenu: boolean): void {
-    let event: Event;
-    const list: Array<Node> = [];
-  
-    (items as Array<MenuItemConstructorOptions>).forEach(item => {
-      let child = this.$(`li.action-item.${item.type === 'separator' || !item.enabled ? 'disable' : ''}`);
-  
-      if(item.type === 'separator') {
-        child.appendChild(this.$('a.action-label.icon.separator.disabled'));
-      } else {
-        const children = [
-          this.$('span.menu-item-check', { 'role': 'none' }),
-          this.$('span.action-label', { 'aria-label': `${item.label}` }, this.getLabelFormat(`${item.label}`)),
-          item.submenu ? this.$('span.submenu-indicator') : this.$('span.keybinding', {}, `${item.accelerator ? item.accelerator : ''}`)
-        ];
-        const menuItem = this.$(`a.action-menu-item.${item.checked ? 'checked': ''}`, { 'role': 'menuitem', 'aria-checked': item.checked }, ...children);
-        child.addEventListener('click', () => {
-          if(item.type === 'checkbox') {
-            menuItem.setAttribute('aria-checked', `${item.checked}`);
-            menuItem.classList.toggle('checked');
-          }
-          if(item.click) item.click(item as MenuItem, remote.getCurrentWindow(), event);
-        });
-        child.appendChild(menuItem);
-      }
-  
-      if(item.submenu || item.type === 'submenu') {
-        const submenu = item.submenu as Menu;
-        if (submenu.items.length) this.createSubmenu(child, submenu.items, true);
-        element.appendChild(child);
-      }
-  
-      list.push(child);
-    });
-  
-    element.appendChild(this.$(`${isSubmenu ? '.submenu.context-view' : ''}.menubar-menu-items-holder.menu-container`, {},
-      this.$('ul.actions-container', { 'role': 'menu' }, ...list))
-    );
+  /**
+   * It method set title horizontal alignment of title-bar.
+   * @param side side of title-bar, available values: (left, center, right).
+   */
+  setHorizontalAlignment(side: string) {
+    setHorizontalAlignment(side);
+  }
+
+  /**
+   * It method getting window controls order what resolved in options.
+   * @returns formatted css style string for html.
+   */
+  private getWindowControlsOrder(): string {
+    if (this.options.order == "inverted") {
+      return "position: absolute; direction: rtl;";
+    } else {
+      return "position: absolute; right: inherit;";
+    }
   }
 }
 
 function showHide(_class: string, _resizer: boolean): void {
   const element = document.querySelector(_class);
-  const wResizer = document.querySelector<HTMLDivElement>('.resizer');
-  
-  if(element) {
-    element.classList.add(_class == '.window-maximize' ? 'window-unmaximize' : 'window-maximize');
-    element.classList.remove(_class == '.window-maximize' ? 'window-maximize' : 'window-unmaximize');
-  }
-  
-  if (wResizer) wResizer.style.display = _resizer ? 'block' : 'none';
-}
+  const wResizer = document.querySelector<HTMLDivElement>(".resizer");
 
-function setEvents(hoverColor: string) {
-  let openedMenu: boolean = false;
-  let selectElementMenu: HTMLElement;
-  let pressed = false;
-  const drag = document.querySelector<HTMLElement>('.titlebar-drag-region');
-
-  // Event to menubar items
-  document.querySelectorAll<HTMLElement>('.menubar-menu-button').forEach((elem) => {
-    elem.addEventListener('click', () => {
-      if(drag && !openedMenu) drag.style.display = 'none';
-      if(drag && openedMenu) drag.removeAttribute('style');
-      (elem.lastChild as HTMLElement).style.left = `${elem.getBoundingClientRect().left}px`;
-      elem.classList.toggle('open');
-      selectElementMenu = elem;
-      openedMenu = !openedMenu;
-    });
-
-    elem.addEventListener('mouseover', () => {
-      if(openedMenu) {
-        selectElementMenu.classList.remove('open');
-        (elem.lastChild as HTMLElement).style.left = `${elem.getBoundingClientRect().left}px`;
-        elem.classList.add('open');
-        selectElementMenu = elem;
-      }
-    });
-  });
-
-  // Event to click outside of menu
-  const container = document.getElementById('content-after-titlebar');
-  if(container) container.addEventListener('click', () => {
-    if(openedMenu) {
-      if(drag) drag.removeAttribute('style');
-      selectElementMenu.classList.remove('open');
-      openedMenu = false;
-    }
-  });
-
-  // Event to menu items
-  document.querySelectorAll('.menubar .action-item:not(.disable)').forEach((elem) => {
-    elem.addEventListener('mouseover', () => {
-      const contentColor = Color(hoverColor).isDark() && hoverColor !== 'transparent' ? '#ffffff' : '#333333';
-      (elem.childNodes[0] as HTMLElement).style.backgroundColor = hoverColor;
-      (elem.childNodes[0] as HTMLElement).style.color = contentColor;
-      (elem.childNodes[0].firstChild as HTMLElement).style.backgroundColor = contentColor;
-      if(!(elem.childNodes[0].lastChild as HTMLElement).classList.contains('keybinding')) {
-        (elem.childNodes[0].lastChild as HTMLElement).style.backgroundColor = contentColor;
-      }
-
-      if((elem.childNodes[0].lastChild as HTMLElement).classList.contains('submenu-indicator')) {
-        (elem.lastChild as HTMLElement).style.left = `${elem.getBoundingClientRect().width}px`;
-        (elem.lastChild as HTMLElement).classList.add('open');
-      }
-    });
-
-    elem.addEventListener('mouseleave', () => {
-      (elem.childNodes[0] as HTMLElement).removeAttribute('style');
-      (elem.childNodes[0].firstChild as HTMLElement).removeAttribute('style');
-      (elem.childNodes[0].lastChild as HTMLElement).removeAttribute('style');
-
-      if((elem.childNodes[0].lastChild as HTMLElement).classList.contains('submenu-indicator')) {
-        (elem.lastChild as HTMLElement).classList.remove('open');
-      }
-    });
-  });
-
-  // Alt key event
-  document.addEventListener('keydown', event => {
-    pressed = !pressed;
-    document.querySelectorAll<HTMLElement>('mnemonic').forEach((elem: HTMLElement) => {
-      if(event.altKey) elem.style.textDecoration = pressed ? 'underline' : '';
-    });
-  });
-}
-
-/**
- * Clean a label
- * @param label Label to clean
- */
-function cleanMnemonic(label: string): string {
-  const regex = /\(&{1,2}(.)\)|&{1,2}(.)/;
-
-  const matches = regex.exec(label);
-  
-  if (!matches) {
-    return label;
+  if (element) {
+    element.classList.add(
+      _class == ".window-maximize" ? "window-unmaximize" : "window-maximize"
+    );
+    element.classList.remove(
+      _class == ".window-maximize" ? "window-maximize" : "window-unmaximize"
+    );
   }
 
-  return label.replace(regex, matches[0].charAt(0) === '&' ? '$2' : '').trim();
+  if (wResizer) wResizer.style.display = _resizer ? "block" : "none";
 }

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -25,6 +25,7 @@ export class Titlebar extends GlobalTitlebar {
     menuBackgroundColor: 'rgba(0, 0, 0, .08)',
     menuSeparatorColor: 'rgba(0, 0, 0, .29)',
     menuLeftPadding: '5px',
+    menuDirection: 'left',
     titleHorizontalAlignment: 'center'
   };
 
@@ -91,8 +92,9 @@ export class Titlebar extends GlobalTitlebar {
     }
 
     if (this.options.menu) {
+      let direction = this.getDirection(this.options.menuDirection);
       titlebarChildren.push(this.$('.window-menu-separator', { 'style': `background: ${this.options.menuSeparatorColor}; width: 100%; height: 1px; top: 30px; position: absolute;` }))
-      titlebarChildren.push(this.$('.window-menu', { 'id': 'window-menu', 'style': `background: ${this.options.menuBackgroundColor}; padding-left: ${this.options.menuLeftPadding}; width: 100%; height: 25px; top: 31px; position: absolute;` }))
+      titlebarChildren.push(this.$('.window-menu', { 'id': 'window-menu', 'style': `background: ${this.options.menuBackgroundColor}; padding-left: ${this.options.menuLeftPadding}; width: 100%; height: 25px; top: 31px; position: absolute; direction: ${direction};` }))
     }
 
     if (platform !== 'darwin') {
@@ -118,6 +120,14 @@ export class Titlebar extends GlobalTitlebar {
     if (this.options.menu) {
       document.getElementById("window-menu")!.appendChild(this.$('.menubar', { 'role': 'menubar' }))
       this.setMenu(this.options.menu);
+    }
+  }
+
+  private getDirection(rawString: string): string {
+    if (rawString == "right") {
+      return "rtl"
+    } else {
+      return "ltr"
     }
   }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39625750/51706231-d5db1500-202e-11e9-8c27-757cd9c97efc.png)

![image](https://user-images.githubusercontent.com/39625750/51706239-decbe680-202e-11e9-86cb-e33cdb9329e8.png)

![image](https://user-images.githubusercontent.com/39625750/51706261-ee4b2f80-202e-11e9-89d9-b77c65534d83.png)

![image](https://user-images.githubusercontent.com/39625750/51706274-facf8800-202e-11e9-83c0-73611a2e98e4.png)

![image](https://user-images.githubusercontent.com/39625750/51706286-07ec7700-202f-11e9-8e7e-a9b08add1e74.png)

![image](https://user-images.githubusercontent.com/39625750/51706296-1044b200-202f-11e9-808a-cc89c9603cac.png)

![image](https://user-images.githubusercontent.com/39625750/51706308-1c307400-202f-11e9-8e67-e5e27eb84257.png)

![image](https://user-images.githubusercontent.com/39625750/51706323-2b172680-202f-11e9-9121-49634d957994.png)

![image](https://user-images.githubusercontent.com/39625750/51706351-441fd780-202f-11e9-8d80-3df3a8deab9b.png)

##### New options:
> ###### `menuBackgroundColor` - background color for bottom title-bar menu, default value is `rgba(0, 0, 0, .08)`.
> ###### `menuInHeader` - boolean value, if `true` menu be displayed in header, default value is `false`.
> ###### `menuSeparatorColor` - fill color for bottom title-bar menu separator, default value is `rgba(0, 0, 0, .29)`.
> ###### `titleHorizontalAlignment` - horizontal alignment of the window title, default value is `center`.
> ###### `titleVisibility` - title text visibility, if `true` - title not be displayed in title-bar. Boolean value.

##### New methods:
> ###### `setIcon` - takes path string to icon.
> ###### `setTitleText` - takes text sting, by default use title from document.
> ###### `setHorizontalAlignment` - takes side string as `titleHorizontalAlignment` option.

##### Removed methods:
> ###### `updateTitle` replaced on `setTitleText`.