### PR TITLE
Prevent accessing undefined elements

### DIFF
--- a/src/common/dom.ts
+++ b/src/common/dom.ts
@@ -1063,15 +1063,19 @@ export function join(nodes: Node[], separator: Node | string): Node[] {
 
 export function show(...elements: HTMLElement[]): void {
 	for (let element of elements) {
-		element.style.display = '';
-		element.removeAttribute('aria-hidden');
+		if (element) {
+			element.style.display = '';
+			element.removeAttribute('aria-hidden');
+		}
 	}
 }
 
 export function hide(...elements: HTMLElement[]): void {
 	for (let element of elements) {
-		element.style.display = 'none';
-		element.setAttribute('aria-hidden', 'true');
+		if (element) {
+			element.style.display = 'none';
+			element.setAttribute('aria-hidden', 'true');
+		}
 	}
 }
 


### PR DESCRIPTION
Prevent accessing object properties when the element is undefined.

For example, [these currently throw and error](https://github.com/AlexTorresSk/custom-electron-titlebar/blob/2ed83fc7a2cbc84e2e749f227a6d0ee30bca27cc/src/titlebar.ts#L347-L349) if the user hasn't defined a titlebar icon.