### PR TITLE
Add support for "visible" prop on MenuItem

### DIFF
--- a/src/menu/menuitem.ts
+++ b/src/menu/menuitem.ts
@@ -117,6 +117,7 @@ export class MenuItem extends Disposable implements IMenuItem {
 		this.updateTooltip();
 		this.updateEnabled();
 		this.updateChecked();
+		this.updateVisibility();
 	}
 
 	onClick(event: EventLike) {
@@ -259,6 +260,12 @@ export class MenuItem extends Disposable implements IMenuItem {
 			this.container.tabIndex = 0;
 		} else {
 			addClass(this.container, 'disabled');
+		}
+	}
+
+	updateVisibility() {
+		if (this.item.visible === false && this.itemElement) {
+			this.itemElement.remove();
 		}
 	}
 


### PR DESCRIPTION
Electron allows you to specify a visible prop on menu items
that will hide and show accordingly. This just adds that same
behavior by calling remove on the html element when not visible.

Issue: 45