### PR TITLE
added overflow as a MenubarOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The interface [`TitleBarOptions`] is managed, which has the following configurab
 | menuPosition             | string           | The position of menubar on titlebar.                                                  | left 											|
 | enableMnemonics          | boolean 					| Enable the mnemonics on menubar and menu items.																				| true											|
 | itemBackgroundColor      | Color            | The background color when the mouse is over the item.                                 | rgba(0, 0, 0, .14)        |
+| overflow                 | string            | The overflow of the container
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The interface [`TitleBarOptions`] is managed, which has the following configurab
 | menuPosition             | string           | The position of menubar on titlebar.                                                  | left 											|
 | enableMnemonics          | boolean 					| Enable the mnemonics on menubar and menu items.																				| true											|
 | itemBackgroundColor      | Color            | The background color when the mouse is over the item.                                 | rgba(0, 0, 0, .14)        |
-| overflow                 | string            | The overflow of the container         | auto
+| overflow                 | string            | The overflow of the container (`auto`, `visible`, `hidden`)         | auto
 
 ## Methods
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The interface [`TitleBarOptions`] is managed, which has the following configurab
 | menuPosition             | string           | The position of menubar on titlebar.                                                  | left 											|
 | enableMnemonics          | boolean 					| Enable the mnemonics on menubar and menu items.																				| true											|
 | itemBackgroundColor      | Color            | The background color when the mouse is over the item.                                 | rgba(0, 0, 0, .14)        |
-| overflow                 | string            | The overflow of the container
+| overflow                 | string            | The overflow of the container         | auto
 
 ## Methods
 

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -67,6 +67,11 @@ export interface TitlebarOptions extends MenubarOptions {
 	 * *The default value is center*
 	 */
 	titleHorizontalAlignment?: "left" | "center" | "right";
+	/**
+	 * Sets the value for the overflow of the window
+	 * *The default value is auto*
+	 */
+	overflow?: "auto" | "hidden" | "visible";
 }
 
 const defaultOptions: TitlebarOptions = {
@@ -77,7 +82,8 @@ const defaultOptions: TitlebarOptions = {
 	minimizable: true,
 	maximizable: true,
 	closeable: true,
-	enableMnemonics: true
+	enableMnemonics: true,
+	overflow: "auto"
 };
 
 export class Titlebar extends Themebar {
@@ -156,7 +162,7 @@ export class Titlebar extends Themebar {
 		this.container.style.right = '0';
 		this.container.style.left = '0';
 		this.container.style.position = 'absolute';
-		this.container.style.overflow = 'auto';
+		this.container.style.overflow = this._options.overflow;
 
 		while (document.body.firstChild) {
 			append(this.container, document.body.firstChild);


### PR DESCRIPTION
Found this very useful for my React project but I was having issues with `overflow: auto` being set for the container. I just added an optional option for the Titlebar constructor that lets you change the default overflow.