### PR TITLE
Fix preload issues

### DIFF
--- a/src/themebar.ts
+++ b/src/themebar.ts
@@ -553,7 +553,8 @@ export interface Theme {
 }
 
 function _applyRules(styleSheetContent: string, rulesClassName: string) {
-    let themeStyles = document.head.getElementsByClassName(rulesClassName);
+    let head = document.head || document.getElementsByTagName("head")[0]
+    let themeStyles = head.getElementsByClassName(rulesClassName);
 
     if (themeStyles.length === 0) {
         let styleElement = document.createElement('style');


### PR DESCRIPTION
![](https://i.imgur.com/KWyrwKX.png)

When using preload scripts in the latest version of Electron, this error occurs. After testing this should fix it.