### PR TITLE
Fix issue #112 and some restyling

### DIFF
--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -20,8 +20,9 @@ const ACTIVE_FOREGROUND_DARK = Color.fromHex('#333333');
 const INACTIVE_FOREGROUND = Color.fromHex('#EEEEEE');
 const ACTIVE_FOREGROUND = Color.fromHex('#FFFFFF');
 
+const IS_MAC_BIGSUR_OR_LATER = isMacintosh && parseInt(process.getSystemVersion().split(".")[0]) >= 11;
 const BOTTOM_TITLEBAR_HEIGHT = '60px';
-const TOP_TITLEBAR_HEIGHT_MAC = '22px';
+const TOP_TITLEBAR_HEIGHT_MAC = IS_MAC_BIGSUR_OR_LATER ? '28px': '22px';
 const TOP_TITLEBAR_HEIGHT_WIN = '30px';
 
 export interface TitlebarOptions extends MenubarOptions {
@@ -227,6 +228,11 @@ export class Titlebar extends Themebar {
 
 		if (!isMacintosh) {
 			this.title.style.cursor = 'default';
+		}
+
+		if (IS_MAC_BIGSUR_OR_LATER) {
+			this.title.style.fontWeight = "600";
+			this.title.style.fontSize = "13px";
 		}
 
 		this.updateTitle();


### PR DESCRIPTION
## Changes
- Fix issue #112
- Restyled `font-size` and `font-weight` to fit the new title bar style of macOS Big Sur.

## Screenshots

### Before

<img width="412" alt="before" src="https://user-images.githubusercontent.com/45519323/102068527-df96dd00-3e3f-11eb-8334-57aabe6ece3a.png">

### After

<img width="412" alt="after" src="https://user-images.githubusercontent.com/45519323/102068539-e45b9100-3e3f-11eb-8098-5e4bace4ae8a.png">


## P.S.
These changes only works on Electron v11 or above. Because the version of macOS always appears as 10.16.0 on Electron v10.