### PR TITLE
Fix some menu actions do not work on Windows

### DIFF
--- a/src/common/enableNativeMenuCommands.ts
+++ b/src/common/enableNativeMenuCommands.ts
@@ -1,0 +1,40 @@
+import { ipcMain, Menu, BrowserWindow, webContents } from "electron"
+
+export function enableNativeMenuCommands(): void {
+
+  ipcMain.on('execute-menu-command', (_, arg: { role: string }): void => {
+    const menu = Menu.getApplicationMenu()
+
+    if (menu !== null) {
+      executeCommandByRole(arg.role, menu)
+    }
+  })
+}
+
+function executeCommandByRole(role: string, menu: Menu): boolean {
+  let index = 0;
+  let done = false;
+
+  while (done === false && index < menu.items.length) {
+    const item = menu.items[index]
+
+    if (item.role === role) {
+      const focusedWindow = BrowserWindow.getFocusedWindow()
+      const focusedWebContents = webContents.getFocusedWebContents()
+
+      item.click(
+        undefined,
+        focusedWindow,
+        focusedWebContents,
+      )
+
+      done = true;
+    } else if (item.submenu) {
+      done = executeCommandByRole(role, item.submenu)
+    }
+
+    index++;
+  }
+
+  return done;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,1 @@
+export * from './common/enableNativeMenuCommands';

--- a/src/menu/menuitem.ts
+++ b/src/menu/menuitem.ts
@@ -9,7 +9,7 @@
  *-------------------------------------------------------------------------------------------------------*/
 
 import { EventType, addDisposableListener, addClass, removeClass, removeNode, append, $, hasClass, EventHelper, EventLike } from "../common/dom";
-import { BrowserWindow, remote, Accelerator, NativeImage, MenuItem } from "electron";
+import { BrowserWindow, remote, Accelerator, NativeImage, MenuItem, ipcRenderer } from "electron";
 import { IMenuStyle, MENU_MNEMONIC_REGEX, cleanMnemonic, MENU_ESCAPED_MNEMONIC_REGEX, IMenuOptions } from "./menu";
 import { KeyCode, KeyCodeUtils } from "../common/keyCodes";
 import { Disposable } from "../common/lifecycle";
@@ -130,9 +130,13 @@ export class CETMenuItem extends Disposable implements IMenuItem {
 	onClick(event: EventLike) {
 		EventHelper.stop(event, true);
 
-		if (this.item.click) {
-			this.item.click(this.item as MenuItem, this.currentWindow, this.event);
-		}
+    if (this.item.role) {
+      ipcRenderer.send('execute-menu-command', {
+        role: this.item.role
+      })
+    } else if (this.item.click) {
+      this.item.click(this.item, this.currentWindow, this.event);
+    }
 
 		if (this.item.type === 'checkbox') {
 			this.item.checked = !this.item.checked;


### PR DESCRIPTION
This pull request is to fix issue https://github.com/AlexTorresSk/custom-electron-titlebar/issues/84

Some menu items do not work because they have to be invoked in the main process (actions like cut, copy, paste) but the TitleBar is rendered in the **renderer** process.

To fix this, we send the commands from the **renderer** process to the **main** process to invoke when user clicks on the menu item. However, user is required to put `enableNativeMenuCommands()` in the main process to listen to commands.

```
// index.ts (main process)
import { enableNativeMenuCommands } from "custom-electron-titlebar/lib/main"; <-- Must import from a separate file 

enableNativeMenuCommands();
```