### PR TITLE
🩹 Added some improvements for the window controls

### DIFF
--- a/src/themebar.ts
+++ b/src/themebar.ts
@@ -444,6 +444,10 @@ export class Themebar extends ThemingRegistry {
             .titlebar .window-controls-container .window-icon-bg.window-close-bg:hover {
                 background-color: rgba(232, 17, 35, 0.9)!important;
             }
+
+            .titlebar .window-controls-container .window-icon-bg.window-close-bg:active {
+                background-color: rgba(232, 17, 35, 0.5)!important;
+            }
             
             .titlebar .window-controls-container .window-icon-bg.inactive {
                 background-color: transparent!important;
@@ -469,8 +473,16 @@ export class Themebar extends ThemingRegistry {
                 background-color: rgba(255, 255, 255, .1);
             }
 
+            .titlebar .window-controls-container .window-icon-bg:not(.inactive):active {
+                background-color: rgba(255, 255, 255, 0.3);
+            }
+
             .titlebar.light .window-controls-container .window-icon-bg:not(.inactive):hover {
                 background-color: rgba(0, 0, 0, .1);
+            }
+
+            .titlebar.light .window-controls-container .window-icon-bg:not(.inactive):active {
+                background-color: rgba(0, 0, 0, .2);
             }
         `);
         });

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -253,6 +253,7 @@ export class Titlebar extends Themebar {
 
 			// Minimize
 			const minimizeIconContainer = append(this.windowControls, $('div.window-icon-bg'));
+			minimizeIconContainer.title = "Minimize";
 			const minimizeIcon = append(minimizeIconContainer, $('div.window-icon'));
 			addClass(minimizeIcon, 'window-minimize');
 
@@ -285,6 +286,7 @@ export class Titlebar extends Themebar {
 
 			// Close
 			const closeIconContainer = append(this.windowControls, $('div.window-icon-bg'));
+			closeIconContainer.title = "Close";
 			addClass(closeIconContainer, 'window-close-bg');
 			const closeIcon = append(closeIconContainer, $('div.window-icon'));
 			addClass(closeIcon, 'window-close');
@@ -361,9 +363,11 @@ export class Titlebar extends Themebar {
 		if (this.maxRestoreControl) {
 			if (maximized) {
 				removeClass(this.maxRestoreControl, 'window-maximize');
+				this.maxRestoreControl.title = "Restore Down"
 				addClass(this.maxRestoreControl, 'window-unmaximize');
 			} else {
 				removeClass(this.maxRestoreControl, 'window-unmaximize');
+				this.maxRestoreControl.title = "Maximize"
 				addClass(this.maxRestoreControl, 'window-maximize');
 			}
 		}


### PR DESCRIPTION
I added native tooltips using the `title` attribute on the HTML elements. Not a big change but it makes it look better because other apps have it and it makes it more realistic

> ## Commit 1:
![image](https://user-images.githubusercontent.com/51731966/104462271-5c9baa80-55d6-11eb-8ff1-c4f8f3e4769b.png)

![image](https://user-images.githubusercontent.com/51731966/104462353-7b01a600-55d6-11eb-878a-0c77b6ba33c6.png)

> ## Commit 2:
When the user clicks the window controls, it has a different color because of the `:active` pseudo selector.

![image](https://user-images.githubusercontent.com/51731966/104570035-6fb28700-5677-11eb-82bd-550c3c5d1a43.png)
![image](https://user-images.githubusercontent.com/51731966/104570054-7640fe80-5677-11eb-91c9-144a69597622.png)

Let me know if any changes are required.
