### PR TITLE
fix menuItem roles

### DIFF
--- a/src/menu/menuitem.ts
+++ b/src/menu/menuitem.ts
@@ -34,7 +34,6 @@ export class CETMenuItem extends Disposable implements IMenuItem {
 	private item: MenuItem;
 
 	private radioGroup: { start: number, end: number }; // used only if item.type === "radio"
-	private accelerator: { modifiers: string[], key: string }; // used only if item.role is defined
 	private labelElement: HTMLElement;
 	private checkElement: HTMLElement;
 	private iconElement: HTMLElement;
@@ -135,11 +134,7 @@ export class CETMenuItem extends Disposable implements IMenuItem {
 	onClick(event: EventLike) {
 		EventHelper.stop(event, true);
 
-		if (this.item.role && this.accelerator) {
-			this.pressKey(this.accelerator.key, this.accelerator.modifiers);
-		} else if (this.item.click) {
-			this.item.click(this.item, this.currentWindow, this.event);
-		}
+		this.item.click(this.event,this.currentWindow, this.currentWindow.webContents);
 
 		if (this.item.type === 'checkbox') {
 			this.updateChecked();
@@ -227,26 +222,8 @@ export class CETMenuItem extends Disposable implements IMenuItem {
 		}
 
 		if (accelerator !== null) {
-			this.accelerator = this.separateAccelerator(accelerator);
 			append(this.itemElement, $('span.keybinding')).textContent = parseAccelerator(accelerator);
 		}
-	}
-
-	pressKey(key: string, modifiers: string[] = []): void {
-		this.currentWindow.webContents.sendInputEvent({
-			type: "keyDown",
-			// @ts-ignore -> modifiers should always be of the right type
-			modifiers,
-			keyCode: key,
-		});
-	}
-
-	separateAccelerator(accelerator: string): { modifiers: string[], key: string } {
-		const result = parseAccelerator(accelerator).split("+");
-		return {
-			modifiers: result.slice(0, -1),
-			key: result[result.length - 1]
-		};
 	}
 
 	updateLabel(): void {

--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -275,10 +275,8 @@ export class Menubar extends Disposable {
 	private onClick(menuIndex: number) {
 		let electronEvent: Electron.Event;
 		const item = this.menuItems[menuIndex].menuItem;
-
-		if (item.click) {
-			item.click(item as MenuItem, remote.getCurrentWindow(), electronEvent);
-		}
+		const browserWindow = remote.getCurrentWindow();
+		item.click(electronEvent, browserWindow, browserWindow.webContents);
 	}
 
 	public get onVisibilityChange(): Event<boolean> {


### PR DESCRIPTION
### Last fix in #148 worked, but it can be fixed in a much better way

The original error came from the fact that `Electron.MenuItem.click()` was called with the wrong parameters:
(those are parameters that the user registered callback for click should receive, but electron takes care of that)

https://github.com/AlexTorresSk/custom-electron-titlebar/blob/8901746f905682f89b0b58378e845fd053437009/src/menu/menuitem.ts#L141

The right parameters for `MenuItem.click` are:
```js
this.click = (event: Event, focusedWindow: BrowserWindow, focusedWebContents: WebContents) => {
```
As defined in [Electron.MenuItem](https://github.com/electron/electron/blob/da8c35e3b256b4f9ad0c16edfbc2b56748b3a740/lib/browser/api/menu-item.ts#L46-L62) 