### PR TITLE
Remove extra space between titlebar and container (macOS 12.1)

### DIFF
--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -141,6 +141,7 @@ export default class Titlebar {
 		if (IS_MAC_BIGSUR_OR_LATER) {
 			this.title.style.fontWeight = "600";
 			this.title.style.fontSize = "13px";
+			this.titlebar.style.height = TOP_TITLEBAR_HEIGHT_MAC;
 		}
 
 		this.updateTitle();


### PR DESCRIPTION
This PR removes the extra space (titlebar height is 22px and not 28px) between the titlebar and the application container that appears when the library is used on macOS 12.1 (IS_MAC_BIGSUR_OR_LATER = true).

<img width="912" alt="custom-titlebar-css-pr" src="https://user-images.githubusercontent.com/1503032/150673046-517376b0-1c5a-4a8f-ac81-a2fd1955d7c4.png">
PS: Changed the background color of the `cet-container` in the screenshot for a better demonstration.

