### PR TITLE
Minor improvements

### DIFF
--- a/example/preload.js
+++ b/example/preload.js
@@ -22,7 +22,7 @@ window.addEventListener('DOMContentLoaded', () => {
 ipcRenderer.on('renderer-titlebar', (event, menu) => {
   titlebar = new cet.Titlebar({
     backgroundColor: cet.Color.fromHex("#388e3c"),
-    icon: new URL(path.join(__dirname, '/assets/images', '/icon.svg')),
+    icon: path.join(__dirname, '/assets/images', '/icon.svg'),
     menu: menu,
     onMinimize: () => ipcRenderer.send('window-event', 'window-minimize'),
     onMaximize: () => ipcRenderer.send('window-event', 'window-maximize'),

--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -470,7 +470,7 @@ export default class Titlebar {
 					addClass(this.title, 'cet-center');
 				}
 
-				if (this.options.order !== 'first-buttons') {
+				if (!isMacintosh && this.options.order !== 'first-buttons') {
 					this.windowControls.style.marginLeft = 'auto';
 				}
 


### PR DESCRIPTION
This PR fixes two things:
* windowsControls variable is undefined on macOS
* an error appears when starting the example app: "Failed to construct 'URL': Invalid URL"