### PR TITLE
Fix type declaration for `menu` option

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -89,7 +89,7 @@ export interface MenubarOptions {
      * You can use `Menu` or not add this option and the menu created in the main process will be taken.
      * **The default menu is undefined**
      */
-    menu?: Menu;
+    menu?: Menu | null;
     /**
      * The position of menubar on titlebar.
      * **The default is left**


### PR DESCRIPTION
When someone uses the library with TypeScript and [strictNullChecks](https://www.typescriptlang.org/tsconfig#strictNullChecks), the `menu` option cannot be set to null, because it's current type is `Menu | undefined`.

![image](https://user-images.githubusercontent.com/31937175/156936650-d80b9226-db6e-4733-aca9-617623b8cb3e.png)

By changing the type in `interfaces.ts`, TypeScript no longer shows an error:

![image](https://user-images.githubusercontent.com/31937175/156936936-8b1db509-78ee-4b7a-ac7d-f6c2015da86b.png)


