### PR TITLE
Update titlebar.ts to remove use of fs module after refactor

### DIFF
--- a/src/titlebar.ts
+++ b/src/titlebar.ts
@@ -8,7 +8,6 @@
  *  Licensed under the MIT License. See License in the project root for license information.
  *-------------------------------------------------------------------------------------------------------*/
 
-import fs from 'fs';
 import { Menu, ipcRenderer } from 'electron';
 import { platform, PlatformToString, isLinux, isMacintosh, isWindows } from 'vs/base/common/platform';
 import { Color, RGBA } from 'vs/base/common/color';
@@ -103,9 +102,7 @@ export default class Titlebar {
 
 	_loadIcons() {
 		if (this._options.icons) {
-			const icons = fs.readFileSync(this._options.icons, 'utf8');
-			const jsonIcons = JSON.parse(icons);
-			this._platformIcons = jsonIcons[PlatformToString(platform).toLocaleLowerCase()];
+			this._platformIcons = this._options.icons[PlatformToString(platform).toLocaleLowerCase()];
 		}
 	}
 


### PR DESCRIPTION
Previous changes i made to this file #194 to remove the use of the fs module were not translated when the pull request was rebased to the development branch because of the previous refactor commit https://github.com/AlexTorresSk/custom-electron-titlebar/commit/d821dc47056f05f63fece4da1d23fee394f9ea1f.

This change is just the same as previous, so see #194 for description of change. 